### PR TITLE
rename "source" field to "fidc_source".

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,6 +106,8 @@ processors:
           fields:
             - from: "payload"
               to: "text_payload"
+            - from: "source"
+              to: "fidc_source"
           ignore_missing: false
           fail_on_error: true
     else:
@@ -150,6 +152,8 @@ processors:
           fields:
             - from: "payload"
               to: "json_payload"
+            - from: "source"
+              to: "fidc_source"
           ignore_missing: false
           fail_on_error: true
 output.elasticsearch:


### PR DESCRIPTION
FIDC changed the log record format leading to errors like:
```
filebeat-forgerock-idcloud | 2022-10-27T20:47:20.045Z   WARN    [elasticsearch] elasticsearch/client.go:408     Cannot index event publisher.Event{Content:beat.Event{Timestamp:time.Time{wall:0x200a8d, ext:63802500420, loc:(*time.Location)(nil)}, Meta:null, Fields:{"agent":{"ephemeral_id":"23414761-877b-4391-99df-fcd7b4aaa71d","hostname":"4dd2ea2780c9","id":"21b9d10b-5d8b-4c96-8e97-bb8ea1c14055","name":"4dd2ea2780c9","type":"filebeat","version":"7.11.1"},"ecs":{"version":"1.6.0"},"event":{"created":"2022-10-27T20:47:19.006Z"},"host":{"name":"4dd2ea2780c9"},"input":{"type":"httpjson"},"json_payload":{"context":"default","level":"DEBUG","logger":"org.forgerock.am.health.ReadinessCheckEndpoint","mdc":{"transactionId":"bf884dec-1829-47fc-9da4-a14fbe589cd3-115746"},"message":"Readiness health check invoked","thread":"http-nio-8080-exec-8","timestamp":"2022-10-27T20:47:00.001Z","transactionId":"bf884dec-1829-47fc-9da4-a14fbe589cd3-115746"},"message":"{\"payload\":{\"context\":\"default\",\"level\":\"DEBUG\",\"logger\":\"org.forgerock.am.health.ReadinessCheckEndpoint\",\"mdc\":{\"transactionId\":\"bf884dec-1829-47fc-9da4-a14fbe589cd3-115746\"},\"message\":\"Readiness health check invoked\",\"thread\":\"http-nio-8080-exec-8\",\"timestamp\":\"2022-10-27T20:47:00.001Z\",\"transactionId\":\"bf884dec-1829-47fc-9da4-a14fbe589cd3-115746\"},\"source\":\"am-core\",\"tenant\":\"https://openam-volker-dev.forgeblocks.com/\",\"timestamp\":\"2022-10-27T20:47:00.002099853Z\",\"type\":\"application/json\"}","source":"am-core","tenant":"https://openam-forgerock-clapmandev.forgeblocks.com/","type":"application/json"}, Private:interface {}(nil), TimeSeries:false}, Flags:0x1, Cache:publisher.EventCache{m:common.MapStr(nil)}} (status=400): {"type":"mapper_parsing_exception","reason":"object mapping for [source] tried to parse field [source] as object, but found a concrete value"}
```